### PR TITLE
Remove CI command to pull version number from swagger.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
       - run:
           command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
           name: Clone ci-scripts
-      - run: cat ./swagger.yml | grep "^  version:" | cut -d":" -f2 | tr -d " " > ./VERSION
       - run: $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN
 
 


### PR DESCRIPTION
## Link to JIRA

[SHAPI-1534](https://clever.atlassian.net/browse/SHAPI-1534)

## Overview

Remove CI command to pull version number from swagger.yml since swagger.yml isn't available in this library template.

## Testing

QAing from my trial of this template with common-api-middleware. See [the failed CI job](https://app.circleci.com/pipelines/github/Clever/common-api-middleware/7/workflows/a0039a96-be1c-496d-a2ac-48d8c15dfeb3/jobs/9). Will be tested when Clever/common-api-middleware#2 is merged.

## Rollout

100

## Rollback (in the event of a problem)
- [ ] Rollback via dapple OR `ark rollback -e production {{.AppName}}`?
- [ ] Anything else?


[SHAPI-1534]: https://clever.atlassian.net/browse/SHAPI-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ